### PR TITLE
Update font_profont_10_72dpi.h

### DIFF
--- a/font_profont_10_72dpi.h
+++ b/font_profont_10_72dpi.h
@@ -4,15 +4,16 @@
 
 #define PROFONT_10_72_HEIGHT 12
 
-const uint8_t profont_10_72_0x21[] __attribute__((__progmem__)) = {   /* '!' width: 6 */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
+const uint8_t profont_10_72_0x21[] __attribute__((__progmem__)) = { /* '!' width: 6 */ 
+0x00, /* [ ] */ 
+0xf0, /* [**] */ 
+0xf0, /* [**] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+
+0xc0, /* [* ] */ 
+0x00, /* [ ] */ 
+0xc0, /* [* ] */ 
 };
 
 const uint8_t profont_10_72_0x22[] __attribute__((__progmem__)) = {   /* '"' width: 6 */
@@ -64,11 +65,12 @@ const uint8_t profont_10_72_0x26[] __attribute__((__progmem__)) = {   /* '&' wid
      0x3c,  0xc0,   /* [ ** *] */
 };
 
-const uint8_t profont_10_72_0x27[] __attribute__((__progmem__)) = {   /* ''' width: 6 */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
+const uint8_t profont_10_72_0x27[] __attribute__((__progmem__)) = { /* ''' width: 6 */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
 };
+
 
 const uint8_t profont_10_72_0x28[] __attribute__((__progmem__)) = {   /* '(' width: 6 */
      0x0c,          /* [  *] */
@@ -920,18 +922,20 @@ const uint8_t profont_10_72_0x7b[] __attribute__((__progmem__)) = {   /* '{' wid
      0x0c,          /* [  *] */
 };
 
-const uint8_t profont_10_72_0x7c[] __attribute__((__progmem__)) = {   /* '|' width: 6 */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0xc0,          /* [*] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
-     0x00,          /* [ ] */
+const uint8_t profont_10_72_0x7c[] __attribute__((__progmem__)) = { /* '|' width: 6 */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+0xc0, /* [* ] */ 
+
 };
+
 
 const uint8_t profont_10_72_0x7d[] __attribute__((__progmem__)) = {   /* '}' width: 6 */
      0xc0,          /* [*  ] */


### PR DESCRIPTION
Replaced the glyph for !  It was blank - never displayed

The fonts in font_profont_10_72dpi.h are messed up for the ! and ' and | bitmaps (or glyphs). I can see why they're printing what they are. For instance, the font bitmap for the | char is:
const uint8_t profont_10_72_0x7c[] **attribute**((**progmem**)) = { /\* '|' width: 6 _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0xc0, /_ [_] */ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] */ 
}; 

The bitmap shown in the comments shows the single pixel in the middle of the glyph, and the setting of 0x00s in the rows with the single 0xc0 in a middle row matches that.

Same for the !, it's all 0x00s:
const uint8_t profont_10_72_0x21[] **attribute**((**progmem**)) = { /\* '!' width: 6 _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
};
and the ', all 0x00s:
const uint8_t profont_10_72_0x27[] **attribute**((**progmem**)) = { /_ ''' width: 6 _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] _/ 
0x00, /_ [ ] */ 
};
That's why they're blank.

Now, I'm not sure what they _should_ be, since I can't quite decode the bitmap values (not sure what the . and \* are in the comments for the glyph 'rows'), but looking at other chars gives a hint. For instance, the [ char is close to the |. Since the [ char is:
const uint8_t profont_10_72_0x5b[] **attribute**((**progmem**)) = { /\* '[' width: 6 _/ 
0xf0, /_ [**] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xf0, /_ [**] */ 
};
then that tells me we could get | by changing the top & bottom 0xf0 to 0xc0.

So, change the corresponding arrays in the file font_profont_10_72dpi.h with these 3:
const uint8_t profont_10_72_0x7c[] **attribute**((**progmem**)) = { /\* '|' width: 6 _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] */ 

};

A ' is close to a |, maybe just the top 3 rows, so it could be:
const uint8_t profont_10_72_0x27[] **attribute**((**progmem**)) = { /\* ''' width: 6 _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] */ 
};

And a ! is close to |, but not as tall and with a blank row on line up from the bottom, and a little fatter up top:
const uint8_t profont_10_72_0x21[] **attribute**((**progmem**)) = { /\* '!' width: 6 _/ 
0x00, /_ [ ] _/ 
0xf0, /_ [**] _/ 
0xf0, /_ [**] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0xc0, /_ [\* ] _/ 
0x00, /_ [ ] _/ 
0xc0, /_ [\* ] _/ 
0x00, /_ [ ] */
};
